### PR TITLE
Oracleでユニークキーに対するFKのメタデータを取得するSQL修正

### DIFF
--- a/dbflute/src/main/java/org/seasar/dbflute/logic/jdbc/metadata/supplement/DfUniqueKeyFkExtractorOracle.java
+++ b/dbflute/src/main/java/org/seasar/dbflute/logic/jdbc/metadata/supplement/DfUniqueKeyFkExtractorOracle.java
@@ -45,11 +45,12 @@ public class DfUniqueKeyFkExtractorOracle extends DfUniqueKeyFkExtractorBase {
         sb.append(" on cons.OWNER = cols.OWNER and cons.CONSTRAINT_NAME = cols.CONSTRAINT_NAME");
         sb.append(" left outer join ALL_CONS_COLUMNS yourCols");
         sb.append(" on cons.R_OWNER = cols.OWNER and cons.R_CONSTRAINT_NAME = yourCols.CONSTRAINT_NAME");
+        sb.append(" and cols.POSITION = yourCols.POSITION");
         sb.append(" where cons.OWNER = '").append(pureSchema).append("'");
         sb.append(" and cons.R_OWNER = '").append(pureSchema).append("'"); // same schema only
         sb.append(" and cons.CONSTRAINT_TYPE = 'R'"); // foreign key
         sb.append(" and yourCons.CONSTRAINT_TYPE = 'U'"); // unique key
-        sb.append(" order by cons.TABLE_NAME, cols.POSITION nulls last");
+        sb.append(" order by cons.TABLE_NAME, cons.CONSTRAINT_NAME, cols.POSITION nulls last");
         final String sql = sb.toString();
         return doSelectUserUniqueFkList(sql, conn);
     }


### PR DESCRIPTION
こんにちは

以前「DBFluteユーザの集い」のほうで「主キーではない項目の外部キー」に対応していただいた阿部です
https://groups.google.com/forum/#!topic/dbflute/ZawZdrkfqQ8

これもその件なのですが、FK(とユニーク制約)が複合キーの場合にうまくキー情報を取得できていないようでした。
該当sqlを修正したので確認&反映していただけたらと思います。

この修正で目的の結果が得られることは確認しました。
