### PR TITLE
Change Spring template to use XML Schema Definition

### DIFF
--- a/dbflute/embedded/templates/om/java/allcommon/container/spring/SpringDBFluteBeans.vm
+++ b/dbflute/embedded/templates/om/java/allcommon/container/spring/SpringDBFluteBeans.vm
@@ -14,11 +14,10 @@
 ## governing permissions and limitations under the License.
 ##
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans
-    PUBLIC "-//SPRING//DTD BEAN 2.0//EN"
-    "http://www.springframework.org/dtd/spring-beans-2.0.dtd"
->
-<beans${database.DBFluteBeansDefaultAttribute}>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+    ${database.DBFluteBeansDefaultAttribute}>
     <!-- The components of DBFlute Runtime. -->
     <bean id="${database.DBFluteInitializerComponentName}" class="${database.DBFluteInitializerClass}">
         <constructor-arg index="0"><ref bean="${database.DBFluteBeansDataSourceName}"/></constructor-arg>


### PR DESCRIPTION
SpringのBean定義ファイルで、DTDではなくXSDを使うよう変更しました。
DTDはSpringのjarに含まれていないため、インターネット接続できない環境だとパースエラーが発生したためです。
XSDはjarに含まれているので、同じ環境でも問題なく動きます。
